### PR TITLE
Update of snap for r53-ddns tag v0.1.3-test2

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,8 +1,8 @@
 title: r53-ddns
 name: r53-ddns
 type: app
-base: core20
-version: 'v0.1.3-test1'
+base: core22
+version: 'v0.1.3-test2'
 summary: r53-ddns Amazon Route 53 DDNS
 description: |
   Amazon Route 53 DDNS - `r53-ddns` - a way to keep a consistant url for a network where the external ip address may change via Amazon Route 53.
@@ -14,15 +14,11 @@ website: https://r53-ddns.noser.net
 icon: img/r53-ddns_icon.png
 license: Apache-2.0
 
-architectures:
-  - amd64
-  - armhf
-  - arm64
 
 parts:
   r53-ddns:
     plugin: rust
-    source: https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v0.1.3-test1.tar.gz
+    source: https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v0.1.3-test2.tar.gz
 
 apps:
   r53-ddns:


### PR DESCRIPTION
Update snap for v0.1.3-test2
- Change to version number
- Change of source file link
- Auto-generated by workflow