### PR TITLE
Update of snap for r53-ddns tag v1.0.6

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@ title: r53-ddns
 name: r53-ddns
 type: app
 base: core20
-version: 'v1.0.5'
+version: 'v1.0.6'
 summary: Set an Amazon Route 53 DNS record for the server/network
 description: |
   Amazon Route 53 DDNS - `r53-ddns` - a way to keep a consistant url for a network where the external ip address may change via Amazon Route 53.
@@ -25,7 +25,7 @@ architectures:
 parts:
   r53-ddns:
     plugin: rust
-    source: https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v1.0.5.tar.gz
+    source: https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v1.0.6.tar.gz
 
 apps:
   r53-ddns:


### PR DESCRIPTION
Update snap for v1.0.6
- Change to version number
- Change of source file link
- Auto-generated by workflow